### PR TITLE
Feat/allow disable

### DIFF
--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -1,42 +1,57 @@
 name: kitchen-tests
 
-on: [push, workflow_dispatch]
+on: [workflow_dispatch]
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2.2.0
-        id: filter
-        with:
-          base: ${{ github.ref }}
-          # inline YAML or path to separate file (e.g.: .github/filters.yaml)
-          filters: |
-            all:
-              - '.github/workflows/kitchen-tests.yml'
-              - 'Dockerfile'
-              - 'Gemfile*'
       - name: Build and Push to Docker Hub
-        if: steps.filter.outputs.all == 'true' && !contains(github.event.commits[0].message, '[skip docker]')
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
           repository: brownccv/kitchen-terraform
           tags: infoblox-record-a
+
   test:
     needs: [docker]
-    if: "!contains(github.event.commits[0].message, '[skip ci]')"
     runs-on: self-hosted
     container: brownccv/kitchen-terraform:infoblox-record-a
     steps:
     - uses: actions/checkout@v2
       with:
         clean: false
+    - name: Remove Kitchen File
+      run: rm -rf .kitchen
+    - name: Remove Terraform Folder
+      run: rm -rf examples/production-record/.terraform
+    - name: Remove Terraform File
+      run: rm -rf examples/production-record/terraform.tfstate.d
     - name: Run Kitchen
       run: kitchen test
       env:
         TF_VAR_infoblox_username: ${{ secrets.INFOBLOX_JHUB_USER }}
         TF_VAR_infoblox_password: ${{ secrets.INFOBLOX_JHUB_PSWD }}
+    - name: Remove Kitchen File
+      run: rm -rf .kitchen
+    - name: Remove Terraform Folder
+      run: rm -rf examples/production-record/.terraform
+    - name: Remove Terraform File
+      run: rm -rf examples/production-record/terraform.tfstate.d
+    - name: Post-check dirty dirs in self-hosted
+      run: |
+        ls -la 
+        ls -la examples/production-record/
 
+  docker-cleanup:
+    needs: [test]
+    runs-on: self-hosted 
+    steps:
+    - name: Clean up docker images
+      run: |
+        docker images --filter=reference='brownccv/kitchen-terraform'
+        docker images --filter=reference='brownccv/kitchen-terraform' --filter "dangling=true" | grep -E "brownccv/kitchen-terraform" | awk '{ print $3 }' | xargs docker rmi || :
+        echo "After cleanup"
+        docker images --filter=reference='brownccv/kitchen-terraform'

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ code by adding a `module` configuration and setting its `source` parameter to UR
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| enabled | Enable this resource? This can go away with terraform v0.13 | `bool` | `true` | no |
 | infoblox\_host | Infoblox host | `string` | n/a | yes |
 | infoblox\_password | Password to authenticate with Infoblox server | `string` | n/a | yes |
 | infoblox\_username | Username to authenticate with Infoblox server | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ provider "infoblox" {
 }
 
 resource "infoblox_a_record" "a_record" {
+  count             = var.enabled ? 1 : 0
   network_view_name = var.record_dns_view
   vm_name           = var.record_hostname
   cidr              = "${var.record_ip}/32"

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable enabled {
-  description = "Enable this respurce? This can go away with terraform v0.13"
+  description = "Enable this resource? This can go away with terraform v0.13"
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable enabled {
+  description = "Enable this respurce? This can go away with terraform v0.13"
+  type        = bool
+  default     = true
+}
+
 variable infoblox_username {
   description = "Username to authenticate with Infoblox server"
   type        = string


### PR DESCRIPTION
* Add a variable to allow disabling the resources. This is a temporary feature for terraform v0.12, where count is not supported for modules. We can remove this when we upgrade to v0.13
* Allow change the workflow to only work on dispatch. I need to verify if that locks PR to not run on self-hosted unless a repo member triggers the workflow manually